### PR TITLE
documentation: reformat icon row

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -45,6 +45,10 @@ section {
     min-height:calc(100% - 1px);
 }
 
+section.no-fullscreen {
+    min-height:initial;
+}
+
 .v-center {
     padding-top:10%;
     font-size:70px;

--- a/documentation/documentation.php
+++ b/documentation/documentation.php
@@ -1,72 +1,74 @@
-<section class="container-fluid" id="section2">
+<section class="container-fluid no-fullscreen" id="section2">
   <div class="row">
-  	<div class="col-sm-8 col-sm-offset-2 text-center">
-        <h1>Documentation</h1>
-        <br>
-		<p class="lead">Get started adding OpenAL to your application today with this documentation in a pdf.</p>
-        <br> 
-      	<A href="openal-1.1-specification.pdf"><i style="font-size:120px" class="fa fa-book fa-5x"></i></a>
-      	<p><A href="openal-1.1-specification.pdf">OpenAL 1.1 specification (PDF)</a></p>
-		<br>
-		<A href="OpenAL_Programmers_Guide.pdf"><i style="font-size:120px" class="fa fa-book fa-5x"></i></a>
-		<p><A href="OpenAL_Programmers_Guide.pdf">OpenAL Programmers Guide (PDF)</a></p>
-		<br>
-		<A href="OpenAL_Effects_Extension_Guide.pdf"><i style="font-size:120px" class="fa fa-book fa-5x"></i></a>
-		<p><A href="OpenAL_Effects_Extension_Guide.pdf">OpenAL Effects Extension Guide (PDF)</a></p>
-		<br>
-		<A href="OpenAL_Deployment_Guide_PCWIN.pdf"><i style="font-size:120px" class="fa fa-book fa-5x"></i></a>
-		<p><A href="OpenAL_Deployment_Guide_PCWIN.pdf">OpenAL Deployment Guide PC/Windows (PDF)</a></p>
+    <div class="col-sm-8 col-sm-offset-2 text-center">
+      <h1>Documentation</h1>
+      <br>
+      <p class="lead">Get started adding OpenAL to your application today with this documentation in a pdf.</p>
+      <div class="col-sm-6 col-md-3"><a href="openal-1.1-specification.pdf">
+	  <i style="font-size:120px" class="fa fa-book fa-5x"></i><br>
+	  OpenAL 1.1 specification (PDF)</a></div>
+      <div class="col-sm-6 col-md-3"><a href="OpenAL_Programmers_Guide.pdf">
+	  <i style="font-size:120px" class="fa fa-book fa-5x"></i><br>
+	  OpenAL Programmers Guide (PDF)</a></div>
+      <div class="clearfix visible-sm"></div>
+      <div class="col-sm-6 col-md-3"><a href="OpenAL_Effects_Extension_Guide.pdf">
+	  <i style="font-size:120px" class="fa fa-book fa-5x"></i><br>
+	  OpenAL Effects Extension Guide (PDF)</a></div>
+      <div class="col-sm-6 col-md-3"><a href="OpenAL_Deployment_Guide_PCWIN.pdf">
+	  <i style="font-size:120px" class="fa fa-book fa-5x"></i><br>
+	  OpenAL Deployment Guide PC/Windows (PDF)</a></p>
+      </div>
     </div>
   </div>
 </section>
 <section class="container-fluid" id="section4">
   <div class="row">
-  	<div class="col-sm-8 col-sm-offset-2 text-left">
+    <div class="col-sm-8 col-sm-offset-2 text-left">
 
-		<h1>Extensions</h1>
-		<h2>Multi-Platform Extensions</h2>
+    <h1>Extensions</h1>
+    <h2>Multi-Platform Extensions</h2>
+    <!-- TODO: use dl dt dd -->
+    <p>These are registered extensions which are used for multiple implementations on multiple platforms.<br />
+    <strong>ALC_ENUMERATION_EXT</strong> -- enumeration of available devices (sample code in altest)<br />
+    <strong>ALC_EXT_CAPTURE</strong> -- capture functionality; documentation is in the OpenAL 1.1 Specification<br />
+    <strong>AL_EXT_MP3</strong> -- MP3 audio format support</p>
+    
+    <h2>Linux/Standard Implementation Extensions</h2>
 
-		<p>These are registered extensions which are used for multiple implementations on multiple platforms.<br />
-		<strong>ALC_ENUMERATION_EXT</strong> -- enumeration of available devices (sample code in altest)<br />
-		<strong>ALC_EXT_CAPTURE</strong> -- capture functionality; documentation is in the OpenAL 1.1 Specification<br />
-		<strong>AL_EXT_MP3</strong> -- MP3 audio format support</p>
-		
-		<h2>Linux/Standard Implementation Extensions</h2>
+    <p><strong>ALC_LOKI_audio_channel</strong> -- get/set the volume settings for the current context<br />
+    <strong>LOKI_buffer_data_callback</strong> -- a buffer callback mechanism<br />
+    <strong>LOKI_IMA_ADPCM_format</strong> -- ADPCM format<br />
+    <strong>LOKI_WAVE_format</strong> -- WAVE format<br />
+    <strong>LOKI_play_position</strong> -- playback position query<br />
+    <strong>LOKI_quadriphonic</strong> -- 4 speaker rendering<br />
+    <strong>EXT_vorbis</strong> -- Ogg Vorbis buffer format</p>
+    
+    <h2>MacOS Extensions</h2>
 
-		<p><strong>ALC_LOKI_audio_channel</strong> -- get/set the volume settings for the current context<br />
-		<strong>LOKI_buffer_data_callback</strong> -- a buffer callback mechanism<br />
-		<strong>LOKI_IMA_ADPCM_format</strong> -- ADPCM format<br />
-		<strong>LOKI_WAVE_format</strong> -- WAVE format<br />
-		<strong>LOKI_play_position</strong> -- playback position query<br />
-		<strong>LOKI_quadriphonic</strong> -- 4 speaker rendering<br />
-		<strong>EXT_vorbis</strong> -- Ogg Vorbis buffer format</p>
-		
-		<h2>MacOS Extensions</h2>
+    <p><strong>ALC_EXT_MAC_OSX</strong>: A Mac OSX-specific extension set.<br />
+    <strong>ALC_EXT_STATIC_BUFFER</strong>: Support for buffers at a static memory location ("no copy buffers").<br />
+    <strong>ALC_EXT_ASA</strong>: Apple Spatial Audio extension.<br />
+    <strong>ALC_EXT_ASA_ROGER_BEEP</strong>: Extends the Apple Spatial Audio Extension (ALC_EXT_ASA) with a Roger Beep Effect when the RogerBeep AudioUnit is present on the system<br />
+    <strong>ALC_EXT_ASA_DISTORTION</strong>: Extends the Apple Spatial Audio Extension (ALC_EXT_ASA) with a Distortion Effect when the Distortion AudioUnit is present on the system</p>
+    
+    <h2>Windows Extensions</h2>
 
-		<p><strong>ALC_EXT_MAC_OSX</strong>: A Mac OSX-specific extension set.<br />
-		<strong>ALC_EXT_STATIC_BUFFER</strong>: Support for buffers at a static memory location ("no copy buffers").<br />
-		<strong>ALC_EXT_ASA</strong>: Apple Spatial Audio extension.<br />
-		<strong>ALC_EXT_ASA_ROGER_BEEP</strong>: Extends the Apple Spatial Audio Extension (ALC_EXT_ASA) with a Roger Beep Effect when the RogerBeep AudioUnit is present on the system<br />
-		<strong>ALC_EXT_ASA_DISTORTION</strong>: Extends the Apple Spatial Audio Extension (ALC_EXT_ASA) with a Distortion Effect when the Distortion AudioUnit is present on the system</p>
-		
-		<h2>Windows Extensions</h2>
+    <p><strong>EAX2.0</strong> -- EAX 2.0 calls<br />
+    <strong>EAX3.0</strong> -- EAX 3.0 calls<br />
+    <strong>EAX4.0</strong> -- EAX 4.0 calls<br />
+    <strong>EAX5.0</strong> -- EAX 5.0 calls<br />
+    <strong>ALC_EXT_EFX</strong> -- Effects Extension (documentation in the OpenAL SDK)<br />
+    <strong>EAX_RAM</strong> -- XRAM support (documentation in the OpenAL SDK)<br />
+    <strong>AL_EXT_ALAW</strong> -- ALAW audio format support<br />
+    <strong>AL_EXT_DOUBLE</strong> -- double audio format support<br />
+    <strong>AL_EXT_FLOAT32</strong> -- float32 audio format support<br />
+    <strong>AL_EXT_IMA4</strong> -- IMA4 audio format support<br />
+    <strong>AL_EXT_MULAW</strong> -- MULAW audio format support<br />
+    <strong>AL_EXT_MCFORMATS</strong> -- multi-channel audio format support</p>
+    
+    <h2>OpenAL Extension API Database</h2>
 
-		<p><strong>EAX2.0</strong> -- EAX 2.0 calls<br />
-		<strong>EAX3.0</strong> -- EAX 3.0 calls<br />
-		<strong>EAX4.0</strong> -- EAX 4.0 calls<br />
-		<strong>EAX5.0</strong> -- EAX 5.0 calls<br />
-		<strong>ALC_EXT_EFX</strong> -- Effects Extension (documentation in the OpenAL SDK)<br />
-		<strong>EAX_RAM</strong> -- XRAM support (documentation in the OpenAL SDK)<br />
-		<strong>AL_EXT_ALAW</strong> -- ALAW audio format support<br />
-		<strong>AL_EXT_DOUBLE</strong> -- double audio format support<br />
-		<strong>AL_EXT_FLOAT32</strong> -- float32 audio format support<br />
-		<strong>AL_EXT_IMA4</strong> -- IMA4 audio format support<br />
-		<strong>AL_EXT_MULAW</strong> -- MULAW audio format support<br />
-		<strong>AL_EXT_MCFORMATS</strong> -- multi-channel audio format support</p>
-		
-		<h2>OpenAL Extension API Database</h2>
-
-		Documentation queries can be made for extension, token or function names at the <a href="http://icculus.org/alextreg/">OpenAL Extension Registry</a>
+    Documentation queries can be made for extension, token or function names at the <a href="http://icculus.org/alextreg/">OpenAL Extension Registry</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
* there's currently a grey thing covering the whole screen, hiding the text below. not good, make it show
* grey thing would still be too tall, so put the icons in the row

PS: why isn't the four-file addition on openal.org? how old is the live version really?